### PR TITLE
perf: pool de conexões PG + índices faltantes + cache de stats

### DIFF
--- a/api.py
+++ b/api.py
@@ -201,9 +201,20 @@ def listar_empresas(
     return resultado
 
 
+# Cache em memória das estatísticas — 5 COUNT(*) full-scan custam caro
+import time as _time
+_stats_cache = {"data": None, "ts": 0}
+_STATS_TTL = 60  # segundos
+
 @app.get("/api/stats")
 def estatisticas(info: dict = Depends(get_token_info)):
-    return db.estatisticas()
+    agora = _time.time()
+    if _stats_cache["data"] and (agora - _stats_cache["ts"]) < _STATS_TTL:
+        return _stats_cache["data"]
+    data = db.estatisticas()
+    _stats_cache["data"] = data
+    _stats_cache["ts"] = agora
+    return data
 
 
 @app.get("/api/cnaes")

--- a/database.py
+++ b/database.py
@@ -18,9 +18,22 @@ USE_POSTGRES = DATABASE_URL.startswith("postgresql") or DATABASE_URL.startswith(
 
 if USE_POSTGRES:
     import psycopg2
-    print("Conectando ao PostgreSQL...")
+    from psycopg2 import pool as _pg_pool
+    from contextlib import contextmanager
+    print("Conectando ao PostgreSQL com pool...")
+    # Pool de conexões reutilizáveis: elimina overhead de TLS+auth a cada query
+    _POOL = _pg_pool.ThreadedConnectionPool(minconn=2, maxconn=20, dsn=DATABASE_URL)
+
+    @contextmanager
     def _conn():
-        return psycopg2.connect(DATABASE_URL)
+        c = _POOL.getconn()
+        try:
+            yield c
+        finally:
+            try:
+                _POOL.putconn(c)
+            except Exception:
+                pass
 else:
     import sqlite3
     print("Usando SQLite local")
@@ -180,8 +193,16 @@ class Database:
                     atualizado_em   TEXT
                 )
             """)
-            for idx in ["uf", "porte", "email", "cnae", "abertura"]:
+            for idx in ["uf", "porte", "email", "cnae", "abertura", "atualizado_em"]:
                 cur.execute(f"CREATE INDEX IF NOT EXISTS idx_{idx} ON empresas({idx})")
+
+            # Índices parciais para os filtros de "tem contato" — só PostgreSQL
+            if USE_POSTGRES:
+                for col in ("telefone", "email", "instagram", "site"):
+                    cur.execute(
+                        f"CREATE INDEX IF NOT EXISTS idx_tem_{col} "
+                        f"ON empresas({col}) WHERE {col} IS NOT NULL AND {col} != ''"
+                    )
             conn.commit()
 
     def criar_tabela_progresso(self):


### PR DESCRIPTION
Os 3 maiores gargalos do sistema, todos no banco:

1. Pool de conexões PostgreSQL (psycopg2.ThreadedConnectionPool min=2/max=20)
   - Antes: cada query abria nova conexão TLS+auth (~80-200ms overhead)
   - Com 15 workers paralelos do agente, isso era catastrófico
   - Reuso de conexões do pool elimina o overhead por query

2. Índices que faltavam:
   - idx_atualizado_em — usado no ORDER BY de TODA busca em buscar_empresas e buscar_cnpjs_sem_contato. Sem isso, full-table scan + sort em 130k+ rows
   - Índices parciais (PG-only) idx_tem_telefone/email/instagram/site — aceleram os filtros "com contato" da listagem padrão

3. Cache em memória das /api/stats (TTL 60s)
   - Antes: 5 COUNT(*) full-scan + 2 GROUP BY a cada 15s por usuário ativo no dashboard (setInterval). Em 130k registros = ~1-2s por chamada
   - Cache zera essa carga, stats só recalcula 1x por minuto